### PR TITLE
Fix time setting and fix communication error recovery

### DIFF
--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/CommunicationService.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/CommunicationService.java
@@ -537,12 +537,12 @@ public class CommunicationService {
      * @return true if data are available from heatpump
      */
     private boolean establishRequest(byte[] request) {
-        int numBytesReadTotal = 0;
         boolean dataAvailable = false;
         int requestRetry = 0;
         int retry = 0;
         try {
             while (requestRetry < maxRetry) {
+                int numBytesReadTotal = 0;
                 connector.write(request);
                 retry = 0;
                 byte singleByte;


### PR DESCRIPTION
### Fix communication error recovery

If the communication had errors, it would introduce a long delay (30-60 minutes) where no data is collected anymore and eventually it would print the error:

```
Could not get data from heat pump! java.lang.ArrayIndexOutOfBoundsException: Index 1024 out of bounds for length 1024
```

This issue is fixed by resetting the offset variable on error.

### Fix setting of time if values need to be unescaped and an off-by-one error in the weekday.

* Weekdays in the heatpump are 0-6, in Java's LocalDateTime they are 1-7 (https://docs.oracle.com/javase/8/docs/api/java/time/DayOfWeek.html#getValue--).
* The logic to set the time did not include the unescaping of the response bytes, so when one of the numbers is 0x10, the received reply would include 0x10 twice and lead to an infinite "retry-request" loop (ignore the different record names):

```
11:16:10.173 [INFO ] [openhab.event.ItemCommandEvent       ] - Item 'StiebelEltronLWZ303SOL_Settime' received command ON
11:16:10.196 [INFO ] [openhab.event.ItemStatePredictedEvent] - Item 'StiebelEltronLWZ303SOL_Settime' predicted to become ON
11:16:10.232 [INFO ] [openhab.event.ItemStateChangedEvent  ] - Item 'StiebelEltronLWZ303SOL_Settime' changed from OFF to ON
11:16:10.264 [DEBUG] [tpump.internal.StiebelHeatPumpHandler] - Received command ON for channelUID stiebelheatpump:LWZ_THZ303_4_39:d4f1ebc8fb:time#setTime
11:16:10.274 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:10.294 [DEBUG] [eatpump.internal.CommunicationService] - Loading current time data ...
11:16:10.303 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 00 FD FC (04)10 03
11:16:10.375 [DEBUG] [eatpump.internal.CommunicationService] - reached end of response message.
11:16:10.384 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parse bytes: (00)01 00 48 FC (04)00 0B 10 10 (08)08 16 0B 07 (12)10 03
11:16:10.394 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Weekday -> 0 with pos: 4 , len: 1
11:16:10.405 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Hour -> 11 with pos: 5 , len: 1
11:16:10.416 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Min -> 16 with pos: 6 , len: 1
11:16:10.426 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Sec -> 16 with pos: 7 , len: 1
11:16:10.437 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Year -> 8 with pos: 8 , len: 1
11:16:10.447 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Month -> 22 with pos: 9 , len: 1
11:16:10.457 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Parsed value time#sTimedate_Day -> 11 with pos: 10 , len: 1
11:16:10.468 [DEBUG] [eatpump.internal.CommunicationService] - Current time is : 2022-11-07T11:16:10.467615
11:16:10.479 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Weekday at position 4 to value 0.
11:16:10.490 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Hour at position 5 to value 11.
11:16:10.501 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Min at position 6 to value 16.
11:16:10.511 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Sec at position 7 to value 10.
11:16:10.521 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Year at position 8 to value 22.
11:16:10.532 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Month at position 9 to value 11.
11:16:10.543 [DEBUG] [g.stiebelheatpump.protocol.DataParser] - Updated record time#sTimedate_Day at position 10 to value 7.
11:16:11.752 [INFO ] [eatpump.internal.CommunicationService] - Time need update. Set time to 2022-11-07T11:16:10.467615
11:16:11.763 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:11.785 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
11:16:16.869 [DEBUG] [eatpump.internal.CommunicationService] - retry request!
11:16:16.878 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:16.901 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
11:16:21.991 [DEBUG] [eatpump.internal.CommunicationService] - retry request!
11:16:22.007 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:22.030 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
11:16:27.111 [DEBUG] [eatpump.internal.CommunicationService] - retry request!
11:16:27.127 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:27.150 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
11:16:32.233 [DEBUG] [eatpump.internal.CommunicationService] - retry request!
11:16:32.250 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:32.270 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
11:16:37.362 [DEBUG] [eatpump.internal.CommunicationService] - retry request!
11:16:37.378 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:37.402 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
11:16:42.486 [DEBUG] [eatpump.internal.CommunicationService] - retry request!
11:16:42.502 [DEBUG] [eatpump.internal.CommunicationService] - Sending start communication
11:16:42.524 [DEBUG] [ebelheatpump.protocol.SerialConnector] - Send request message : (00)01 80 D1 FC (04)00 0B 10 0A (08)16 0B 07 07 (12)10 03
```