### PR TITLE
Stiebel binding cleanup

### DIFF
--- a/bom/openhab-addons/pom.xml
+++ b/bom/openhab-addons/pom.xml
@@ -1543,6 +1543,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.addons.bundles</groupId>
+      <artifactId>org.openhab.binding.stiebelheatpump</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.addons.bundles</groupId>
       <artifactId>org.openhab.binding.surepetcare</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.binding.stiebelheatpump/pom.xml
+++ b/bundles/org.openhab.binding.stiebelheatpump/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.stiebelheatpump</artifactId>

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/feature/feature.xml
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/feature/feature.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features name="org.openhab.binding.stiebelheatpump-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-    <feature name="openhab-binding-stiebelheatpump" description="stiebelheatpump Binding" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <feature>openhab-transport-serial</feature>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.stiebelheatpump/${project.version}</bundle>
-    </feature>
+	<feature name="openhab-binding-stiebelheatpump" description="stiebelheatpump Binding" version="${project.version}">
+		<feature>openhab-runtime-base</feature>
+		<feature>openhab-transport-serial</feature>
+		<bundle start-level="80">mvn:org.openhab.addons.bundles/org.openhab.binding.stiebelheatpump/${project.version}</bundle>
+	</feature>
 </features>

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/CommunicationService.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/CommunicationService.java
@@ -537,12 +537,12 @@ public class CommunicationService {
      * @return true if data are available from heatpump
      */
     private boolean establishRequest(byte[] request) {
-        int numBytesReadTotal = 0;
         boolean dataAvailable = false;
         int requestRetry = 0;
         int retry = 0;
         try {
             while (requestRetry < maxRetry) {
+                int numBytesReadTotal = 0;
                 connector.write(request);
                 retry = 0;
                 byte singleByte;

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/CommunicationService.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/CommunicationService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -33,20 +33,23 @@ import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @author Stefan Triller
+ */
 public class CommunicationService {
 
-    private Logger logger = LoggerFactory.getLogger(CommunicationService.class);
+    private final Logger logger = LoggerFactory.getLogger(CommunicationService.class);
 
-    private ProtocolConnector connector;
-    private int maxRetry = 5;
-    private static int inputBufferLength = 1024;
+    private final ProtocolConnector connector;
+    private final int maxRetry = 5;
+    private static final int inputBufferLength = 1024;
     private byte[] buffer = new byte[inputBufferLength];
 
     DataParser parser = new DataParser();
 
-    private SerialPortManager serialPortManager;
-    private String serialPortName;
-    private int baudRate;
+    private final SerialPortManager serialPortManager;
+    private final String serialPortName;
+    private final int baudRate;
     private int waitingTime = 1200;
 
     public CommunicationService(SerialPortManager serialPortManager, String serialPortName, int baudRate,
@@ -217,7 +220,7 @@ public class CommunicationService {
                 }
                 success = true;
             } catch (StiebelHeatPumpException e) {
-                logger.warn("Error reading data  for {}: {} -> Retry: {}", requestStr, e.toString(), count);
+                logger.warn("Error reading data for {}: {} -> Retry: {}", requestStr, e, count);
             }
         }
         if (!success) {
@@ -252,7 +255,7 @@ public class CommunicationService {
                 }
                 success = true;
             } catch (StiebelHeatPumpException e) {
-                logger.warn("Error reading data  for {}: {} -> Retry: {}", requestStr, e.toString(), count);
+                logger.warn("Error reading data for {}: {} -> Retry: {}", requestStr, e, count);
             }
         }
         if (!success) {
@@ -386,9 +389,9 @@ public class CommunicationService {
             }
 
         } catch (StiebelHeatPumpException e) {
-            logger.error("Stiebel heat pump communication error during update of value !");
+            logger.error("Stiebel heat pump communication error during update of value!");
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            logger.error("Interrupted", e);
         }
         return data;
     }
@@ -518,7 +521,7 @@ public class CommunicationService {
             connector.write(DataParser.STARTCOMMUNICATION);
             response = connector.get();
         } catch (Exception e) {
-            throw new StiebelHeatPumpException("heat pump communication could not be established !" + e.getMessage());
+            throw new StiebelHeatPumpException("heat pump communication could not be established!" + e.getMessage());
         }
         if (response != DataParser.ESCAPE) {
             throw new StiebelHeatPumpException(
@@ -632,7 +635,7 @@ public class CommunicationService {
             requestMessage = parser.addDuplicatedBytes(requestMessage);
         } catch (StiebelHeatPumpException e) {
             String requestStr = String.format("%02X", requestytes);
-            logger.error("Could not create request [{}] message !", requestStr, e.toString());
+            logger.error("Could not create request [{}] message: {}", requestStr, e.toString());
         }
         return requestMessage;
     }

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/ConfigLocator.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/ConfigLocator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/ConfigParser.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/ConfigParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -62,11 +62,11 @@ public class ConfigParser {
             records = (Records) xstream.fromXML(x);
 
             if (records == null) {
-                logger.debug("Records could not be desialized from: {} " + configFile.toString());
+                logger.debug("Records could not be deserialized from: {}", configFile.toString());
                 return null;
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("IO error while parsing configuration", e);
         }
 
         return records;

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/Record.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/Record.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/Records.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/Records.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -116,5 +116,4 @@ public class Records {
 
         return requests;
     }
-
 }

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpBindingConstants.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpBindingConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpConfigOptionProvider.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpConfigOptionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpConfiguration.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpException.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -34,5 +34,4 @@ public class StiebelHeatPumpException extends Exception {
     public StiebelHeatPumpException(Throwable cause) {
         super(cause);
     }
-
 }

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpHandler.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpHandler.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.stiebelheatpump.internal;
 
@@ -130,7 +134,7 @@ public class StiebelHeatPumpHandler extends BaseThingHandler {
                 case CHANNEL_REQUESTBYTES:
                     String requestStr = command.toString();
                     byte[] debugBytes = DataParser.hexStringToByteArray(requestStr);
-                    logger.debug("Dump responds for request byte {} !", requestStr);
+                    logger.debug("Dump responds for request byte {}!", requestStr);
                     String respondStr = communicationService.dumpRequest(debugBytes);
                     updateRespondChannel(respondStr);
                     logger.debug("Response from heatpump: {}", respondStr);
@@ -168,7 +172,7 @@ public class StiebelHeatPumpHandler extends BaseThingHandler {
                             LocalTime time = LocalTime.parse(command.toString(), strictTimeFormatter);
                             value = (short) (time.getHour() * 100 + time.getMinute());
                         } catch (DateTimeParseException e) {
-                            logger.info("Time string is not valid ! : {}", e.getMessage());
+                            logger.info("Time string is not valid! : {}", e.getMessage());
                         }
                     }
                     data = communicationService.writeData(value, channelId, updateRecord);
@@ -193,7 +197,7 @@ public class StiebelHeatPumpHandler extends BaseThingHandler {
         String channelId = channelUID.getId();
         Request request = heatPumpConfiguration.getRequestByChannelId(channelId);
         if (request == null) {
-            logger.debug("No Request found for channelid {} !", channelId);
+            logger.debug("No Request found for channelid {}!", channelId);
             return;
         }
         if (scheduledRequests.getRequests().contains(request)) {
@@ -314,7 +318,7 @@ public class StiebelHeatPumpHandler extends BaseThingHandler {
                 return;
             }
         } catch (StiebelHeatPumpException e) {
-            logger.debug(e.getMessage());
+            logger.debug("{}", e.getMessage());
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "Communication problem with heatpump");
             communicationService.finalizer();
@@ -374,7 +378,7 @@ public class StiebelHeatPumpHandler extends BaseThingHandler {
                 Map<String, Object> time = communicationService.setTime(timeRequest);
                 updateChannels(time);
             } catch (StiebelHeatPumpException e) {
-                logger.debug(e.getMessage());
+                logger.debug("{}", e.getMessage());
             } finally {
                 communicationInUse.unlock();
             }

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpHandlerFactory.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/internal/StiebelHeatPumpHandlerFactory.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.stiebelheatpump.internal;
 

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/ByteStreamPipe.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/ByteStreamPipe.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -81,7 +81,7 @@ public class ByteStreamPipe implements Runnable {
             try {
                 if (in.available() > 0) {
                     byte readByte = (byte) in.read();
-                    logger.trace(String.format("Received %02X", readByte));
+                    logger.trace("{}", String.format("Received %02X", readByte));
                     buffer.put(readByte);
                 }
                 Thread.sleep(3);

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/CircularByteBuffer.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/CircularByteBuffer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -125,5 +125,4 @@ public class CircularByteBuffer {
     public void stop() {
         running = false;
     }
-
 }

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/DataParser.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/DataParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -196,10 +196,10 @@ public class DataParser {
             if (newValue instanceof Double) {
                 Double newValueDouble = (Double) newValue;
                 if (newValueDouble > recordDefinition.getMax() || newValueDouble < recordDefinition.getMin()) {
-                    logger.warn("The record {} can not be set to value {} as allowed range is {}<-->{} !",
+                    logger.warn("The record {} can not be set to value {} as allowed range is {}<-->{}!",
                             recordDefinition.getChannelid(), newValue, recordDefinition.getMax(),
                             recordDefinition.getMin());
-                    throw new StiebelHeatPumpException("invalid value !");
+                    throw new StiebelHeatPumpException("invalid value!");
                 }
                 newValueShort = (short) (newValueDouble / recordDefinition.getScale());
             }
@@ -207,10 +207,10 @@ public class DataParser {
             if (newValue instanceof Short) {
                 newValueShort = (Short) newValue;
                 if (newValueShort > recordDefinition.getMax() || newValueShort < recordDefinition.getMin()) {
-                    logger.warn("The record {} can not be set to value {} as allowed range is {}<-->{} !",
+                    logger.warn("The record {} can not be set to value {} as allowed range is {}<-->{}!",
                             recordDefinition.getChannelid(), newValue, recordDefinition.getMax(),
                             recordDefinition.getMin());
-                    throw new StiebelHeatPumpException("invalid value !");
+                    throw new StiebelHeatPumpException("invalid value!");
                 }
             }
 
@@ -231,8 +231,8 @@ public class DataParser {
         }
         response[2] = this.calculateChecksum(response);
         this.addDuplicatedBytes(response);
-        logger.debug("Updated record {} at position {} to value {}.", recordDefinition.getChannelid(),
-                recordDefinition.getPosition(), newValue);
+        logger.debug("Updated record {} at position {} with length {} to value {}.", recordDefinition.getChannelid(),
+                recordDefinition.getPosition(), recordDefinition.getLength(), newValue);
         return response;
     }
 

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/ProtocolConnector.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/ProtocolConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -15,6 +15,9 @@ package org.openhab.binding.stiebelheatpump.protocol;
 import org.openhab.binding.stiebelheatpump.internal.StiebelHeatPumpException;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 
+/**
+ * @author Stefan Triller
+ */
 public interface ProtocolConnector {
 
     public abstract void connect(SerialPortManager portManager, String s, int i) throws StiebelHeatPumpException;

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/RecordDefinition.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/RecordDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/Request.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/Request.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/Requests.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/Requests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -13,6 +13,7 @@
 package org.openhab.binding.stiebelheatpump.protocol;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -84,7 +85,7 @@ public class Requests {
 
     public Request getRequestByByte(byte[] requestByte) {
         for (Request request : requestList) {
-            if (request.getRequestByte() == requestByte) {
+            if (Arrays.equals(request.getRequestByte(), requestByte)) {
                 return request;
             }
         }

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/SerialConnector.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/java/org/openhab/binding/stiebelheatpump/protocol/SerialConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2020 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -148,7 +148,7 @@ public class SerialConnector implements ProtocolConnector {
     public void write(byte data) throws StiebelHeatPumpException {
         try {
             String byteStr = String.format("Send %02X", data);
-            logger.trace(byteStr);
+            logger.trace("{}", byteStr);
             out.write(data);
             out.flush();
         } catch (IOException e) {

--- a/bundles/org.openhab.binding.stiebelheatpump/src/main/resources/OH-INF/binding/binding.xml
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/main/resources/OH-INF/binding/binding.xml
@@ -3,11 +3,10 @@
 	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
-    <name>Stiebel Eltron heat pump Binding</name>
-    <description>This binding is used to communicate Stiebel Eltron LWZ heat pumps via a serial interface.
-    The binding is inspired by the work of [Monitoring a Stiebel Eltron LWZ (http://robert.penz.name/heat-pump-lwz) which is hosted at
-    Heatpumpmonitor (https://launchpad.net/heatpumpmonitor)
-    and is written in Python.</description>
-    <author>Peter Kreutzer</author>
+	<name>Stiebel Eltron heat pump Binding</name>
+	<description>This binding is used to communicate Stiebel Eltron LWZ heat pumps via a serial interface. The binding is
+		inspired by the work of [Monitoring a Stiebel Eltron LWZ (http://robert.penz.name/heat-pump-lwz) which is hosted at
+		Heatpumpmonitor (https://launchpad.net/heatpumpmonitor) and is written in Python.</description>
+	<author>Peter Kreutzer</author>
 
 </binding:binding>

--- a/bundles/org.openhab.binding.stiebelheatpump/src/test/java/org/openhab/binding/stiebelheatpump/internal/CommunicationServiceTests.java
+++ b/bundles/org.openhab.binding.stiebelheatpump/src/test/java/org/openhab/binding/stiebelheatpump/internal/CommunicationServiceTests.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.binding.stiebelheatpump.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,6 +32,9 @@ import org.openhab.core.io.transport.serial.SerialPortIdentifier;
 import org.openhab.core.io.transport.serial.SerialPortManager;
 import org.openhab.core.util.HexUtils;
 
+/**
+ * @author Stefan Triller
+ */
 public class CommunicationServiceTests {
 
     SerialPortManager serialPortManager = mock(SerialPortManager.class);
@@ -91,5 +106,4 @@ public class CommunicationServiceTests {
 
         return connector;
     }
-
 }

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -342,6 +342,7 @@
     <module>org.openhab.binding.souliss</module>
     <module>org.openhab.binding.spotify</module>
     <module>org.openhab.binding.squeezebox</module>
+    <module>org.openhab.binding.stiebelheatpump</module>
     <module>org.openhab.binding.surepetcare</module>
     <module>org.openhab.binding.synopanalyzer</module>
     <module>org.openhab.binding.systeminfo</module>


### PR DESCRIPTION
This PR is the result of making changes required by the OpenHAB build system, by running `mvn spotless:apply` and some minor, manual changes to the log statements.

It looks like some files have CRLF line endings and spotless:apply turned them into LF.

The other two commits should go away once #6 is merged.